### PR TITLE
Remove unused modifiers

### DIFF
--- a/contracts/Folia.sol
+++ b/contracts/Folia.sol
@@ -23,26 +23,12 @@ contract Folia is ERC721Full, Ownable {
         _;
     }
 
-    modifier onlyAdmin() {
-        require(_admins.has(msg.sender), "DOES_NOT_HAVE_ADMIN_ROLE");
-        _;
-    }
-    
-    /**
-    * @dev Checks msg.sender can transfer a token, by being owner, approved, operator or controller
-    * @param _tokenId uint256 ID of the token to validate
-    */
-    modifier canTransfer(uint256 _tokenId) {
-        require(_isApprovedOrOwner(msg.sender, _tokenId) || msg.sender == controller);
-        _;
-    }
-
     constructor(string memory name, string memory symbol, address _metadata) public ERC721Full(name, symbol) {
         metadata = _metadata;
         _admins.add(msg.sender);
         admins += 1;
     }
-    
+
     function mint(address recepient, uint256 tokenId) public onlyAdminOrController {
         _mint(recepient, tokenId);
     }


### PR DESCRIPTION
Unused modifiers are not part of the compiled bytecode so removing them doesn't make deployment cheaper but make the source code more readable.